### PR TITLE
Add simple PHP backend for Spicette

### DIFF
--- a/Spicette/admin.php
+++ b/Spicette/admin.php
@@ -1,0 +1,56 @@
+<?php
+session_start();
+if (!isset($_SESSION['username']) || empty($_SESSION['is_admin'])) {
+    header('Location: login.php');
+    exit;
+}
+$pinsFile = __DIR__ . '/data/pins.json';
+$pins = json_decode(file_get_contents($pinsFile), true);
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (isset($_POST['delete'])) {
+        $id = (int)$_POST['delete'];
+        $pins = array_filter($pins, function($p) use ($id) { return $p['id'] !== $id; });
+        file_put_contents($pinsFile, json_encode(array_values($pins), JSON_PRETTY_PRINT));
+    } elseif (isset($_POST['img'], $_POST['source'])) {
+        $new = ['id' => count($pins) ? max(array_column($pins, 'id')) + 1 : 1,
+                'img' => $_POST['img'], 'source' => $_POST['source']];
+        $pins[] = $new;
+        file_put_contents($pinsFile, json_encode($pins, JSON_PRETTY_PRINT));
+    }
+    header('Location: admin.php');
+    exit;
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Admin - Spicette</title>
+</head>
+<body>
+<h2>Admin Panel</h2>
+<p><a href="index.php">Home</a> | <a href="logout.php">Logout</a></p>
+<h3>Add Pin</h3>
+<form method="post">
+    <input type="text" name="img" placeholder="Image URL" required>
+    <input type="text" name="source" placeholder="Source" required>
+    <button type="submit">Add</button>
+</form>
+<h3>Existing Pins</h3>
+<table border="1" cellpadding="5">
+<tr><th>ID</th><th>Image</th><th>Source</th><th>Action</th></tr>
+<?php foreach ($pins as $p): ?>
+<tr>
+<td><?= $p['id'] ?></td>
+<td><img src="<?= htmlspecialchars($p['img']) ?>" width="100"></td>
+<td><?= htmlspecialchars($p['source']) ?></td>
+<td>
+    <form method="post" style="display:inline">
+        <button type="submit" name="delete" value="<?= $p['id'] ?>">Delete</button>
+    </form>
+</td>
+</tr>
+<?php endforeach; ?>
+</table>
+</body>
+</html>

--- a/Spicette/data/pins.json
+++ b/Spicette/data/pins.json
@@ -1,0 +1,7 @@
+[
+    {"id": 1, "img": "https://picsum.photos/236/350?random=1", "source": "example.com"},
+    {"id": 2, "img": "https://picsum.photos/236/420?random=2", "source": "another.com"},
+    {"id": 3, "img": "https://picsum.photos/236/300?random=3", "source": "website.org"},
+    {"id": 4, "img": "https://picsum.photos/236/500?random=4", "source": "testsite.dev"},
+    {"id": 5, "img": "https://picsum.photos/236/380?random=5", "source": "coolpics.io"}
+]

--- a/Spicette/data/users.json
+++ b/Spicette/data/users.json
@@ -1,0 +1,3 @@
+[
+    {"username": "admin", "password": "password123", "isAdmin": true}
+]

--- a/Spicette/index.php
+++ b/Spicette/index.php
@@ -1,0 +1,36 @@
+<?php
+session_start();
+$pins = json_decode(file_get_contents(__DIR__ . '/data/pins.json'), true);
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Spicette</title>
+<style>
+body {font-family: Arial, sans-serif;background:#f0f0f0;margin:0;padding:0;}
+header {background:#ef5350;color:#fff;padding:1rem;text-align:center;}
+.masonry {column-count:4;column-gap:1em;padding:1em;}
+.item {background:white;margin:0 0 1em;display:inline-block;width:100%;border-radius:8px;overflow:hidden;box-shadow:0 2px 5px rgba(0,0,0,0.3);}
+.item img {width:100%;display:block;}
+@media (max-width:1000px){.masonry{column-count:3;}}
+@media (max-width:700px){.masonry{column-count:2;}}
+@media (max-width:400px){.masonry{column-count:1;}}
+</style>
+</head>
+<body>
+<header>
+<h1>Welcome to Spicette</h1>
+<?php if(isset($_SESSION['username'])): ?>
+<p>Logged in as <?= htmlspecialchars($_SESSION['username']) ?> | <a href="logout.php" style="color:white;">Logout</a> <?php if(!empty($_SESSION['is_admin'])): ?>| <a href="admin.php" style="color:white;">Admin</a><?php endif; ?></p>
+<?php else: ?>
+<p><a href="login.php" style="color:white;">Login</a> or <a href="register.php" style="color:white;">Register</a></p>
+<?php endif; ?>
+</header>
+<div class="masonry">
+<?php foreach($pins as $p): ?>
+<div class="item"><img src="<?= htmlspecialchars($p['img']) ?>" alt="Image"></div>
+<?php endforeach; ?>
+</div>
+</body>
+</html>

--- a/Spicette/login.php
+++ b/Spicette/login.php
@@ -1,0 +1,37 @@
+<?php
+session_start();
+$error = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $username = trim($_POST['username'] ?? '');
+    $password = trim($_POST['password'] ?? '');
+    $users = json_decode(file_get_contents(__DIR__ . '/data/users.json'), true);
+    foreach ($users as $user) {
+        if ($user['username'] === $username && $user['password'] === $password) {
+            $_SESSION['username'] = $user['username'];
+            $_SESSION['is_admin'] = !empty($user['isAdmin']);
+            header('Location: index.php');
+            exit;
+        }
+    }
+    $error = 'Invalid credentials';
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Login - Spicette</title>
+</head>
+<body>
+<h2>Login</h2>
+<?php if ($error): ?>
+<p style="color:red;"><?= htmlspecialchars($error) ?></p>
+<?php endif; ?>
+<form method="post">
+    <label>Username: <input type="text" name="username" required></label><br>
+    <label>Password: <input type="password" name="password" required></label><br>
+    <button type="submit">Login</button>
+</form>
+<p><a href="register.php">Register</a></p>
+</body>
+</html>

--- a/Spicette/logout.php
+++ b/Spicette/logout.php
@@ -1,0 +1,5 @@
+<?php
+session_start();
+session_destroy();
+header('Location: login.php');
+exit;

--- a/Spicette/pins.php
+++ b/Spicette/pins.php
@@ -1,0 +1,14 @@
+<?php
+header('Content-Type: application/json');
+$pinsFile = __DIR__ . '/data/pins.json';
+if (!file_exists($pinsFile)) {
+    echo json_encode([]);
+    exit;
+}
+$pins = file_get_contents($pinsFile);
+if ($pins === false) {
+    echo json_encode([]);
+    exit;
+}
+// simply output
+echo $pins;

--- a/Spicette/register.php
+++ b/Spicette/register.php
@@ -1,0 +1,47 @@
+<?php
+session_start();
+$error = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $username = trim($_POST['username'] ?? '');
+    $password = trim($_POST['password'] ?? '');
+    if ($username === '' || $password === '') {
+        $error = 'Both fields are required';
+    } else {
+        $file = __DIR__ . '/data/users.json';
+        $users = json_decode(file_get_contents($file), true);
+        foreach ($users as $user) {
+            if ($user['username'] === $username) {
+                $error = 'Username already exists';
+                break;
+            }
+        }
+        if (!$error) {
+            $users[] = ['username' => $username, 'password' => $password, 'isAdmin' => false];
+            file_put_contents($file, json_encode($users, JSON_PRETTY_PRINT));
+            $_SESSION['username'] = $username;
+            $_SESSION['is_admin'] = false;
+            header('Location: index.php');
+            exit;
+        }
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Register - Spicette</title>
+</head>
+<body>
+<h2>Register</h2>
+<?php if ($error): ?>
+<p style="color:red;"><?= htmlspecialchars($error) ?></p>
+<?php endif; ?>
+<form method="post">
+    <label>Username: <input type="text" name="username" required></label><br>
+    <label>Password: <input type="password" name="password" required></label><br>
+    <button type="submit">Register</button>
+</form>
+<p><a href="login.php">Login</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `Spicette` directory with PHP pages
- implement login/register/logout with session storage
- add admin page to manage pins
- store user and pin data as JSON
- simple home page showing pins

## Testing
- `php -l Spicette/index.php` *(fails: `bash: php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_6853d4709acc8323a226f517dd15c5fe